### PR TITLE
#29 웹 푸시 알림 전송 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ dependencies {
     implementation 'eu.bitwalker:UserAgentUtils:1.21'
     // https://mvnrepository.com/artifact/nl.martijndwars/web-push
     implementation 'nl.martijndwars:web-push:5.1.2'
-    // https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
+    // https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
     implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
     // https://mvnrepository.com/artifact/org.bitbucket.b_c/jose4j

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,14 @@ dependencies {
     implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     // https://mvnrepository.com/artifact/eu.bitwalker/UserAgentUtils
     implementation 'eu.bitwalker:UserAgentUtils:1.21'
+    // https://mvnrepository.com/artifact/nl.martijndwars/web-push
+    implementation 'nl.martijndwars:web-push:5.1.2'
+    // https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
+    // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
+    // https://mvnrepository.com/artifact/org.bitbucket.b_c/jose4j
+    implementation 'org.bitbucket.b_c:jose4j:0.9.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/oneseoktwojo/ohtalkhae/config/SecurityConfig.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/refresh").permitAll()
                         .requestMatchers("/auth/logout").permitAll()
                         .requestMatchers("/auth/verify").permitAll()
+                        .requestMatchers("/notification/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/oneseoktwojo/ohtalkhae/config/WebPushConfig.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/config/WebPushConfig.java
@@ -1,0 +1,35 @@
+package oneseoktwojo.ohtalkhae.config;
+
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.spec.InvalidKeySpecException;
+
+@Configuration
+public class WebPushConfig {
+
+    @Value("${webpush.public-key}")
+    private String publicKey;
+
+    @Value("${webpush.private-key}")
+    private String privateKey;
+
+    @Bean
+    public PushService pushService() throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        PushService pushService = new PushService();
+        pushService.setPublicKey(publicKey);
+        pushService.setPrivateKey(privateKey);
+
+        return pushService;
+    }
+}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationController.java
@@ -2,10 +2,13 @@ package oneseoktwojo.ohtalkhae.domain.notification;
 
 import eu.bitwalker.useragentutils.UserAgent;
 import lombok.RequiredArgsConstructor;
-import oneseoktwojo.ohtalkhae.domain.notification.dto.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.request.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.response.DeviceListResponse;
+import oneseoktwojo.ohtalkhae.global.dto.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +30,12 @@ public class PushNotificationController {
     @PostMapping("/unsubscribe")
     public void unsubscribe(@RequestBody PushSubscribeRequest request) {
         pushNotificationService.unsubscribe(request);
+    }
+
+    @GetMapping("/devices")
+    public ApiResponse<List<DeviceListResponse>> getSubscribedDevices(@RequestParam Long userId) {
+        List<DeviceListResponse> subscribedDevices = pushNotificationService.getSubscribedDevices(userId);
+        return ApiResponse.success(200, subscribedDevices);
     }
 
     private String parseDeviceName(String userAgentString) {

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
-import oneseoktwojo.ohtalkhae.domain.notification.dto.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.auth.User;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.request.PushSubscribeRequest;
 import oneseoktwojo.ohtalkhae.domain.notification.dto.WebPushMessage;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.response.DeviceListResponse;
 import oneseoktwojo.ohtalkhae.domain.notification.mapper.PushSubscriptionMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +39,14 @@ public class PushNotificationService {
         Optional<PushSubscription> subscriptionOptional =
                 pushSubscriptionRepository.findByEndPoint(request.getEndPoint());
         subscriptionOptional.ifPresent(pushSubscriptionRepository::delete);
+    }
+
+    public List<DeviceListResponse> getSubscribedDevices(Long userId) {
+        List<PushSubscription> subscriptions = pushSubscriptionRepository.findByUserId(userId);
+
+        return subscriptions.stream()
+                .map(s -> DeviceListResponse.of(s))
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
@@ -1,13 +1,21 @@
 package oneseoktwojo.ohtalkhae.domain.notification;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
 import oneseoktwojo.ohtalkhae.domain.notification.dto.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.WebPushMessage;
 import oneseoktwojo.ohtalkhae.domain.notification.mapper.PushSubscriptionMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -15,6 +23,8 @@ public class PushNotificationService {
 
     private final PushSubscriptionRepository pushSubscriptionRepository;
     private final PushSubscriptionMapper pushSubscriptionMapper;
+    private final PushService pushService;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public PushSubscription subscribe(PushSubscribeRequest request) {
@@ -29,4 +39,32 @@ public class PushNotificationService {
         subscriptionOptional.ifPresent(pushSubscriptionRepository::delete);
     }
 
+    @Transactional
+    public void sendPushTo(Long userId, WebPushMessage message, LocalDateTime now) {
+
+        List<PushSubscription> subscriptions = pushSubscriptionRepository.findByUserId(userId);
+        if (subscriptions.isEmpty())
+            return;
+
+        for (PushSubscription subscription : subscriptions) {
+            try {
+                Notification notification = new Notification(
+                        subscription.getEndPoint(),
+                        subscription.getPublicKey(),
+                        subscription.getAuth(),
+                        objectMapper.writeValueAsBytes(message)
+                );
+
+                pushService.send(notification);
+
+                subscription.setLastUsedAt(now);
+                pushSubscriptionRepository.save(subscription);
+            }
+            catch (Exception e) {
+                log.info("Failed to send push notification to user {}.", userId, e);
+            }
+        }
+    }
+
+    // TODO sendPushTo userId 리스트 버전 만들기
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationService.java
@@ -46,6 +46,20 @@ public class PushNotificationService {
         if (subscriptions.isEmpty())
             return;
 
+        sendNotifications(subscriptions, message, now);
+    }
+
+    @Transactional
+    public void sendPushTo(List<Long> userIds, WebPushMessage message, LocalDateTime now) {
+
+        List<PushSubscription> subscriptions = pushSubscriptionRepository.findByUserIdIn(userIds);
+        if (subscriptions.isEmpty())
+            return;
+
+        sendNotifications(subscriptions, message, now);
+    }
+
+    private void sendNotifications(List<PushSubscription> subscriptions, WebPushMessage message, LocalDateTime now) {
         for (PushSubscription subscription : subscriptions) {
             try {
                 Notification notification = new Notification(
@@ -61,10 +75,8 @@ public class PushNotificationService {
                 pushSubscriptionRepository.save(subscription);
             }
             catch (Exception e) {
-                log.info("Failed to send push notification to user {}.", userId, e);
+                log.info("Failed to send push notification to user {}.", subscription.getUserId(), e);
             }
         }
     }
-
-    // TODO sendPushTo userId 리스트 버전 만들기
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushSubscriptionRepository.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/PushSubscriptionRepository.java
@@ -11,6 +11,8 @@ public interface PushSubscriptionRepository extends JpaRepository<PushSubscripti
 
     List<PushSubscription> findByUserId(Long userId);
 
+    List<PushSubscription> findByUserIdIn(List<Long> userIds);
+
     Optional<PushSubscription> findByEndPoint(String endPoint);
 
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/WebPushMessage.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/WebPushMessage.java
@@ -1,0 +1,19 @@
+package oneseoktwojo.ohtalkhae.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class WebPushMessage {
+
+    public String title;
+    public String body;
+    public String clickTarget;
+
+    @Builder
+    public WebPushMessage(String title, String body, String clickTarget) {
+        this.title = title;
+        this.body = body;
+        this.clickTarget = clickTarget;
+    }
+}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/request/PushSubscribeRequest.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/request/PushSubscribeRequest.java
@@ -1,4 +1,4 @@
-package oneseoktwojo.ohtalkhae.domain.notification.dto;
+package oneseoktwojo.ohtalkhae.domain.notification.dto.request;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/response/DeviceListResponse.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/dto/response/DeviceListResponse.java
@@ -1,0 +1,33 @@
+package oneseoktwojo.ohtalkhae.domain.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import oneseoktwojo.ohtalkhae.domain.notification.PushSubscription;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DeviceListResponse {
+
+    private Long subscriptionId;
+    private String deviceName;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastUsedAt;
+
+    @Builder
+    public DeviceListResponse(Long subscriptionId, String deviceName, LocalDateTime createdAt, LocalDateTime lastUsedAt) {
+        this.subscriptionId = subscriptionId;
+        this.deviceName = deviceName;
+        this.createdAt = createdAt;
+        this.lastUsedAt = lastUsedAt;
+    }
+
+    public static DeviceListResponse of(PushSubscription subscription) {
+        return DeviceListResponse.builder()
+                .subscriptionId(subscription.getSubscriptionId())
+                .deviceName(subscription.getDeviceName())
+                .createdAt(subscription.getCreatedAt())
+                .lastUsedAt(subscription.getLastUsedAt())
+                .build();
+    }
+}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/mapper/PushSubscriptionMapper.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/notification/mapper/PushSubscriptionMapper.java
@@ -1,7 +1,7 @@
 package oneseoktwojo.ohtalkhae.domain.notification.mapper;
 
 import oneseoktwojo.ohtalkhae.domain.notification.PushSubscription;
-import oneseoktwojo.ohtalkhae.domain.notification.dto.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.request.PushSubscribeRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+webpush:
+  public-key: BBtyefD63XsMWfBgtJtzZ-Elh9lt3P68G6oKMoJMDUsjNAOEQjqvxOV-OgDYJuLWlIAc8YaQ2TCkzn2bkiIhDO0=
+  private-key: ODSO8Kqw0AMFHT4koLhNxG9ZwfY5jDOwG59EbRcZwZM

--- a/src/test/java/oneseoktwojo/ohtalkhae/ControllerTestSupport.java
+++ b/src/test/java/oneseoktwojo/ohtalkhae/ControllerTestSupport.java
@@ -1,15 +1,22 @@
-package oneseoktwojo.ohtalkhae.domain;
+package oneseoktwojo.ohtalkhae;
 
+import oneseoktwojo.ohtalkhae.config.SecurityConfig;
+import oneseoktwojo.ohtalkhae.domain.auth.jwt.JWTUtil;
 import oneseoktwojo.ohtalkhae.domain.notification.PushNotificationController;
 import oneseoktwojo.ohtalkhae.domain.notification.PushNotificationService;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(controllers = {
     PushNotificationController.class
 })
+@Import(SecurityConfig.class)
 public class ControllerTestSupport {
 
     @MockitoBean
     private PushNotificationService pushNotificationService;
+
+    @MockitoBean
+    private JWTUtil jwtUtil;
 }

--- a/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationControllerTest.java
+++ b/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationControllerTest.java
@@ -1,13 +1,12 @@
 package oneseoktwojo.ohtalkhae.domain.notification;
 
-import oneseoktwojo.ohtalkhae.domain.ControllerTestSupport;
+import oneseoktwojo.ohtalkhae.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationServiceTest.java
+++ b/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushNotificationServiceTest.java
@@ -1,13 +1,15 @@
 package oneseoktwojo.ohtalkhae.domain.notification;
 
 import oneseoktwojo.ohtalkhae.IntegrationTestSupport;
-import oneseoktwojo.ohtalkhae.domain.notification.dto.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.request.PushSubscribeRequest;
+import oneseoktwojo.ohtalkhae.domain.notification.dto.response.DeviceListResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +71,23 @@ class PushNotificationServiceTest extends IntegrationTestSupport {
 
         // when then
         pushNotificationService.unsubscribe(request);
+    }
+
+    @DisplayName("구독 중인 장치 목록을 조회합니다.")
+    @Test
+    void getSubscribedDevices() {
+        // given
+        Long userId = 1L;
+        String endPoint = "https://fcm.googleapis.com/fcm/send/cx1Ykq8bSxE:APA91bF3YX98k0p-EXAMPLE_END_POINT";
+        PushSubscribeRequest request = createPushSubscribeRequest(userId, endPoint);
+        PushSubscription saved = pushNotificationService.subscribe(request);
+
+        // when
+        List<DeviceListResponse> devices = pushNotificationService.getSubscribedDevices(userId);
+
+        // then
+        assertThat(devices).hasSize(1);
+        assertThat(devices.get(0).getSubscriptionId()).isEqualTo(saved.getSubscriptionId());
     }
 
     private PushSubscribeRequest createPushSubscribeRequest(Long userId, String endPoint) {

--- a/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushSubscriptionRepositoryTest.java
+++ b/src/test/java/oneseoktwojo/ohtalkhae/domain/notification/PushSubscriptionRepositoryTest.java
@@ -43,6 +43,33 @@ class PushSubscriptionRepositoryTest extends IntegrationTestSupport {
                 .containsExactly(tuple(userId1, endPoint1));
     }
 
+    @DisplayName("userId 리스트를 이용하여 푸시 알림 구독 목록을 조회합니다.")
+    @Test
+    void findByUserIdIn() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        Long userId3 = 3L;
+        String endPoint1 = "https://fcm.googleapis.com/fcm/send/cx1Ykq8bSxE:APA91bF3YX98k0p-EXAMPLE_END_POINT_USER1";
+        String endPoint2 = "https://fcm.googleapis.com/fcm/send/cx1Ykq8bSxE:APA91bF3YX98k0p-EXAMPLE_END_POINT_USER2";
+        String endPoint3 = "https://fcm.googleapis.com/fcm/send/cx1Ykq8bSxE:APA91bF3YX98k0p-EXAMPLE_END_POINT_USER3";
+
+        pushSubscriptionRepository.save(createPushSubscription(userId1, endPoint1));
+        pushSubscriptionRepository.save(createPushSubscription(userId2, endPoint2));
+        pushSubscriptionRepository.save(createPushSubscription(userId3, endPoint3));
+
+        // when
+        List<PushSubscription> found = pushSubscriptionRepository.findByUserIdIn(List.of(1L, 3L));
+
+        // then
+        assertThat(found).hasSize(2)
+                .extracting("userId", "endPoint")
+                .containsExactlyInAnyOrder(
+                        tuple(userId1, endPoint1),
+                        tuple(userId3, endPoint3)
+                );
+    }
+
     @DisplayName("endPoint를 이용하여 푸시 알림 구독 목록을 조회합니다.")
     @Test
     void findByEndPoint() {


### PR DESCRIPTION
웹 푸시 알림을 전송하는 기능을 추가하였습니다.

- WebPush와 관련된 의존성 추가
- Service에 userId를 이용해 한 명의 회원에게 푸시 알림을 전송하는 메서드 추가
- userId 리스트를 이용해 여러 명의 회원에게 푸시 알림 전송하는 메서드 추가
- 푸시 알림을 구독 중인 장치 목록을 조회하는 엔드포인트 추가

### 참고자료

[웹 푸시 작동 방식 관련 자료](https://godsenal.com/posts/web-push-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0/#%EB%8F%99%EC%9E%91-%EB%B0%A9%EC%8B%9D)

closes #29 