### PR TITLE
Feature/#45-profile-status-and-read-api

### DIFF
--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/entity/User.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/entity/User.java
@@ -31,4 +31,6 @@ public class User {
     private Role role;
     @CreatedDate
     private LocalDateTime createdAt;
+    private String nickname;
+    private String profileImagePath;
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/entity/User.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/entity/User.java
@@ -33,4 +33,5 @@ public class User {
     private LocalDateTime createdAt;
     private String nickname;
     private String profileImagePath;
+    private String statusMessage;
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/repository/UserRepository.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/auth/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByEmail(String email);
     Boolean existsByPhone(String phone);
     User findByUsername(String username);
+    Boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/controller/EmojiController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/controller/EmojiController.java
@@ -1,8 +1,6 @@
 package oneseoktwojo.ohtalkhae.domain.emoji.controller;
 
 import lombok.RequiredArgsConstructor;
-oneseoktwojo.ohtalkhae.domain.emoji.dto.response.EmojiListResponse;
-oneseoktwojo.ohtalkhae.domain.emoji.dto.response.EmojiRegisterResponse;
 import oneseoktwojo.ohtalkhae.domain.emoji.service.EmojiService;
 import oneseoktwojo.ohtalkhae.domain.emoji.dto.request.EmojiRegisterRequest;
 import oneseoktwojo.ohtalkhae.domain.emoji.dto.response.EmojiDetailResponse;

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/repository/EmojiImageRepository.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/repository/EmojiImageRepository.java
@@ -1,4 +1,4 @@
-package oneseoktwojo.ohtalkhae.domain.emoji.repository.;
+package oneseoktwojo.ohtalkhae.domain.emoji.repository;
 
 import oneseoktwojo.ohtalkhae.domain.emoji.entity.EmojiImage;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/repository/EmojiRepository.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/emoji/repository/EmojiRepository.java
@@ -1,4 +1,4 @@
-package oneseoktwojo.ohtalkhae.domain.emoji.repository.;
+package oneseoktwojo.ohtalkhae.domain.emoji.repository;
 
 import oneseoktwojo.ohtalkhae.domain.emoji.entity.Emoji;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
@@ -3,6 +3,8 @@ package oneseoktwojo.ohtalkhae.domain.profile.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import oneseoktwojo.ohtalkhae.domain.profile.dto.NicknameUpdateRequest;
+import oneseoktwojo.ohtalkhae.domain.profile.dto.ProfileResponse;
+import oneseoktwojo.ohtalkhae.domain.profile.dto.StatusMessageUpdateRequest;
 import oneseoktwojo.ohtalkhae.domain.profile.service.ProfileInfoService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,5 +30,11 @@ public class ProfileInfoController {
             @Valid @RequestBody StatusMessageUpdateRequest request) {
         profileInfoService.updateStatusMessage(userId, request.getStatusMessage());
         return ResponseEntity.ok("상태 메시지가 성공적으로 변경되었습니다.");
+    }
+
+    @GetMapping
+    public ResponseEntity<ProfileResponse> getProfileInfo(@PathVariable Long userId){
+        ProfileResponse profileResponse = profileInfoService.getProfileInfo(userId);
+        return ResponseEntity.ok(profileResponse);
     }
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
@@ -9,13 +9,15 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/{userId}/profile")
+@RequestMapping("/api/users/{userId}/profile/info")
 public class ProfileInfoController {
 
     private final ProfileInfoService profileInfoService;
 
     @PutMapping("/nickname")
-    public ResponseEntity<String> updateNickname(@PathVariable Long userId, @Valid @RequestBody NicknameUpdateRequest request){
+    public ResponseEntity<String> updateNickname(
+            @PathVariable Long userId,
+            @Valid @RequestBody NicknameUpdateRequest request) {
         profileInfoService.updateNickname(userId, request.getNickname());
         return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
     }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/ProfileInfoController.java
@@ -21,4 +21,12 @@ public class ProfileInfoController {
         profileInfoService.updateNickname(userId, request.getNickname());
         return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
     }
+
+    @PutMapping("/status-message")
+    public ResponseEntity<String> updateStatusMessage(
+            @PathVariable Long userId,
+            @Valid @RequestBody StatusMessageUpdateRequest request) {
+        profileInfoService.updateStatusMessage(userId, request.getStatusMessage());
+        return ResponseEntity.ok("상태 메시지가 성공적으로 변경되었습니다.");
+    }
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/UserProfileController.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/controller/UserProfileController.java
@@ -10,13 +10,15 @@ import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/{userId}/profile")
+@RequestMapping("/api/users/{userId}/profile/image")
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
 
-    @PostMapping("/image")
-    public ResponseEntity<String> uploadProfileImage(@PathVariable Long userId, @RequestParam("image") MultipartFile file) throws IOException {
+    @PostMapping
+    public ResponseEntity<String> uploadProfileImage(
+            @PathVariable Long userId,
+            @RequestParam("image") MultipartFile file) throws IOException {
         String uploadedFileName = userProfileService.uploadProfileImage(userId, file);
         return ResponseEntity.ok("프로필 사진이 성공적으로 업로드되었습니다. 파일 이름: " + uploadedFileName);
     }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/dto/ProfileResponse.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/dto/ProfileResponse.java
@@ -1,0 +1,20 @@
+package oneseoktwojo.ohtalkhae.domain.profile.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import oneseoktwojo.ohtalkhae.domain.auth.entity.User;
+
+@Setter
+@Getter
+public class ProfileResponse {
+
+    private String nickname;
+    private String statusMessage;
+    private String profileImagePath;
+
+    public ProfileResponse(User user) {
+        this.nickname = user.getNickname();
+        this.statusMessage = user.getStatusMessage();
+        this.profileImagePath = user.getProfileImagePath();
+    }
+}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/dto/StatusMessageUpdateRequest.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/dto/StatusMessageUpdateRequest.java
@@ -1,0 +1,13 @@
+package oneseoktwojo.ohtalkhae.domain.profile.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StatusMessageUpdateRequest {
+
+    @Size(max = 30, message = "상태 메시지는 최대 30자까지 입력 가능합니다.")
+    private String statusMessage;
+}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
@@ -1,8 +1,8 @@
 package oneseoktwojo.ohtalkhae.domain.profile.service;
 
 import lombok.RequiredArgsConstructor;
-import oneseoktwojo.ohtalkhae.domain.auth.AuthRepository;
-import oneseoktwojo.ohtalkhae.domain.auth.User;
+import oneseoktwojo.ohtalkhae.domain.auth.entity.User;
+import oneseoktwojo.ohtalkhae.domain.auth.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,17 +11,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProfileInfoService {
 
-    private final AuthRepository authRepository;
+    private final UserRepository userRepository;
 
     public void updateNickname(Long userId, String newNickname) {
-
-        if (authRepository.existsByNickname(newNickname)) {
+        if (userRepository.existsByNickname(newNickname)) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        User user = authRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
         user.setNickname(newNickname);
-        authRepository.save(user);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
@@ -3,12 +3,13 @@ package oneseoktwojo.ohtalkhae.domain.profile.service;
 import lombok.RequiredArgsConstructor;
 import oneseoktwojo.ohtalkhae.domain.auth.entity.User;
 import oneseoktwojo.ohtalkhae.domain.auth.repository.UserRepository;
+import oneseoktwojo.ohtalkhae.domain.profile.dto.ProfileResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ProfileInfoService {
 
     private final UserRepository userRepository;
@@ -29,5 +30,11 @@ public class ProfileInfoService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
         user.setStatusMessage(newStatusMessage);
         userRepository.save(user);
+    }
+
+    public ProfileResponse getProfileInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
+        return new ProfileResponse(user);
     }
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/ProfileInfoService.java
@@ -23,4 +23,11 @@ public class ProfileInfoService {
         user.setNickname(newNickname);
         userRepository.save(user);
     }
+
+    public void updateStatusMessage(Long userId, String newStatusMessage) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
+        user.setStatusMessage(newStatusMessage);
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/UserProfileService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/UserProfileService.java
@@ -1,46 +1,46 @@
-package oneseoktwojo.ohtalkhae.domain.profile.service;
+    package oneseoktwojo.ohtalkhae.domain.profile.service;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import oneseoktwojo.ohtalkhae.domain.auth.AuthRepository;
-import oneseoktwojo.ohtalkhae.domain.auth.User;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
+    import java.io.IOException;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    import java.nio.file.Paths;
+    import java.nio.file.StandardCopyOption;
+    import java.util.UUID;
+    import lombok.RequiredArgsConstructor;
+    import oneseoktwojo.ohtalkhae.domain.auth.entity.User;
+    import oneseoktwojo.ohtalkhae.domain.auth.repository.UserRepository;
+    import org.springframework.beans.factory.annotation.Value;
+    import org.springframework.stereotype.Service;
+    import org.springframework.transaction.annotation.Transactional;
+    import org.springframework.web.multipart.MultipartFile;
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class UserProfileService {
+    @Service
+    @RequiredArgsConstructor
+    @Transactional
+    public class UserProfileService {
 
-    @Value("${file.upload.path}")
-    private String uploadPath;
+        @Value("${file.upload.path}")
+        private String uploadPath;
 
-    private final AuthRepository authRepository;
+        private final UserRepository userRepository;
 
-    public String uploadProfileImage(Long userId, MultipartFile file) throws IOException {
-        if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        public String uploadProfileImage(Long userId, MultipartFile file) throws IOException {
+            if (file == null || file.isEmpty()) {
+                throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+            }
+
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            String newFilename = UUID.randomUUID().toString() + fileExtension;
+            Path targetPath = Paths.get(uploadPath, newFilename);
+
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
+            user.setProfileImagePath(newFilename);
+            userRepository.save(user);
+
+            return newFilename;
         }
-
-        String originalFilename = file.getOriginalFilename();
-        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
-        String newFilename = UUID.randomUUID().toString() + fileExtension;
-        Path targetPath = Paths.get(uploadPath, newFilename);
-
-        Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
-
-        User user = authRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
-        user.setProfileImagePath(newFilename);
-        authRepository.save(user);
-
-        return newFilename;
     }
-}

--- a/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/UserProfileService.java
+++ b/src/main/java/oneseoktwojo/ohtalkhae/domain/profile/service/UserProfileService.java
@@ -5,6 +5,8 @@
     import java.nio.file.Path;
     import java.nio.file.Paths;
     import java.nio.file.StandardCopyOption;
+    import java.util.Arrays;
+    import java.util.List;
     import java.util.UUID;
     import lombok.RequiredArgsConstructor;
     import oneseoktwojo.ohtalkhae.domain.auth.entity.User;
@@ -30,7 +32,13 @@
             }
 
             String originalFilename = file.getOriginalFilename();
-            String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".")).toLowerCase();
+
+            List<String> allowedExtensions = Arrays.asList(".jpg", ".jpeg", ".png", ".gif");
+            if (!allowedExtensions.contains(fileExtension)) {
+                throw new IllegalArgumentException("허용되지 않은 파일 확장자입니다. : " + fileExtension);
+            }
+
             String newFilename = UUID.randomUUID().toString() + fileExtension;
             Path targetPath = Paths.get(uploadPath, newFilename);
 


### PR DESCRIPTION
상태메시지 변경과 프로필 보기 api를 구현했습니다.

- **API 엔드포인트 추가:**
    - `PUT /api/users/{userId}/profile/info/status-message`: 사용자 상태 메시지 변경 API
    - `GET /api/users/{userId}/profile/info`: 사용자 프로필 정보 조회 API 
- **요청 데이터 DTO 구현:** `StatusMessageUpdateRequest`
- **응답 데이터 DTO 구현:** `ProfileResponse`
- **컨트롤러 메소드 구현:** `ProfileInfoController`에 상태 메시지 변경 요청 처리 및 프로필 정보 조회 요청 처리
- **서비스 메소드 구현:** `ProfileInfoService`에 사용자 조회 및 상태 메시지 업데이트 로직, 사용자 정보 조회 로직
- **폴더 구조 변경에 따른 임포트 업데이트**

조언해주시면 감사합니다.